### PR TITLE
fix: set Postgres version to fix Docker setup

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:16-alpine
     environment:
       POSTGRES_DB: blogbowl
       POSTGRES_USER: development

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   postgres-test:
-    image: postgres:latest
+    image: postgres:16-alpine
     environment:
       POSTGRES_DB: test
       POSTGRES_USER: test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
 
   postgres:
-    image: postgres:latest
+    image: postgres:16-alpine
     environment:
       POSTGRES_DB: blogbowl
       POSTGRES_USER: blogbowl


### PR DESCRIPTION
# Fix PostgreSQL container startup failure

## Problem

The PostgreSQL container was failing to start with the following error:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).
```

This occurred because:
- The `docker-compose.yaml` was using `postgres:latest` which defaults to PostgreSQL 18+
- PostgreSQL 18+ introduced a breaking change in how data directories are structured
- Existing volumes created with older PostgreSQL versions are incompatible with this new structure

## Solution

Pin PostgreSQL to version 16 (stable LTS release) instead of using `:latest`.

### Changes

**docker-compose.yaml:**
```diff
  postgres:
-   image: postgres:latest
+   image: postgres:16-alpine
    environment:
      POSTGRES_DB: blogbowl
      POSTGRES_USER: blogbowl
```

### Why PostgreSQL 16?

- **Stability**: PostgreSQL 16 is a stable, well-tested LTS release
- **Compatibility**: Works with the existing data directory structure (`/var/lib/postgresql/data`)
- **Predictability**: Pinning versions prevents unexpected breaking changes in production
- **Best Practice**: Production environments should always use specific versions, not `:latest`

### Alternative Approach (Not Implemented)

If we wanted to use PostgreSQL 18+, we would need to change the volume mount structure:

```yaml
postgres:
  image: postgres:latest
  volumes:
    - bb_postgres_data:/var/lib/postgresql  # Remove /data suffix
```

This approach was **not chosen** because:
- It requires migration of existing data
- PostgreSQL 18 is newer and less battle-tested
- Version pinning provides better stability

## Testing

After applying this change:

1. Remove the old incompatible volume:
   ```bash
   docker compose down
   docker volume rm blogbowl_bb_postgres_data
   ```

2. Start fresh:
   ```bash
   docker compose up -d
   ```

3. Verify PostgreSQL is healthy:
   ```bash
   docker compose ps
   docker logs blogbowl-postgres-1
   ```

Expected output should include:
```
database system is ready to accept connections
```

## Impact

- **Breaking Change**: Requires removal of existing PostgreSQL volumes
- **Data Loss**: Any existing data in the database will be lost (acceptable for new deployments)
- **Migration Required**: For existing deployments with data, see migration guide below

## Migration Guide for Existing Data

If you have existing data that needs to be preserved:

1. **Backup existing data:**
   ```bash
   docker compose exec postgres pg_dump -U blogbowl blogbowl > backup.sql
   ```

2. **Apply this PR changes**

3. **Remove old volume and restart:**
   ```bash
   docker compose down
   docker volume rm blogbowl_bb_postgres_data
   docker compose up -d
   ```

4. **Restore data:**
   ```bash
   docker compose exec -T postgres psql -U blogbowl blogbowl < backup.sql
   ```

## Additional Notes

- The `-alpine` variant is used for smaller image size
- PostgreSQL 16 will receive updates until November 2028
- Consider upgrading to PostgreSQL 17 in the future when it becomes more widely adopted

## Checklist

- [x] Changed `postgres:latest` to `postgres:16-alpine`
- [x] Tested container startup
- [x] Verified database connectivity